### PR TITLE
Hotfix to CarDetailsInfo and Tailwind.config.js

### DIFF
--- a/src/components/CarDetailsInfo.js
+++ b/src/components/CarDetailsInfo.js
@@ -19,7 +19,7 @@ export default function CarDetailsInfo({ selectedCar }) {
     };
 
     return (
-        <div className='w-701'>
+        <div className='w-full'>
             <div className='border border-black'>
 
                 <div className='img-container aspect-w-16 aspect-h-9 border-b border-black flex justify-center'>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,12 +17,6 @@ export const theme = {
       'regular': 400,
       'bold': 700,
     },
-    height: {
-      '128': '32rem',
-    },
-    width: {
-      '701': '43.813rem',
-    },
     zIndex: {
       '100': '100',
       '1100': '1100',


### PR DESCRIPTION
CarDetailsInfo - I made the parent container have the w-full class instead of w-701. The latter class was causing the img to blow up in mobile. Now with the w-full class the img looks normal in mobile view.
Tailwind.config.js - I cleaned up the file a bit by removing the custom height and width classes I added. They are no longer needed as we are using the aspect plugin now.